### PR TITLE
Add bricks to list of mineable_by_all list

### DIFF
--- a/src/main/resources/data/peripherals/tags/blocks/mineable_by_any.json
+++ b/src/main/resources/data/peripherals/tags/blocks/mineable_by_any.json
@@ -6,6 +6,7 @@
     "minecraft:deepslate",
     "minecraft:cobblestone",
     "minecraft:mossy_cobblestone",
+    "minecraft:bricks",
     "#minecraft:stone_bricks",
     "#minecraft:coal_ores"
   ]


### PR DESCRIPTION
Fixes #43

Just adds bricks to the list in 
`src/main/resources/data/peripherals/tags/blocks/mineable_by_all.json`